### PR TITLE
add NextTrigger timestamp variable

### DIFF
--- a/AnwesenheitsSimulation/module.php
+++ b/AnwesenheitsSimulation/module.php
@@ -25,7 +25,7 @@ class AnwesenheitsSimulation extends IPSModule
 
         //Variables
         $this->RegisterVariableString('SimulationView', $this->Translate('Simulation preview'), '~HTMLBox');
-        $this->RegisterVariableString('NextTrigger', $this->Translate('Next Trigger'), '');
+        $this->RegisterVariableInteger('NextTrigger', $this->Translate('Next Trigger'), '');
         $this->RegisterVariableString('SimulationDay', $this->Translate('Simulations source (Day)'), '');
         $this->RegisterVariableBoolean('Active', $this->Translate('Simulation active'), '~Switch');
         $this->EnableAction('Active');
@@ -151,7 +151,7 @@ class AnwesenheitsSimulation extends IPSModule
             $this->SetValue('SimulationDay', 'Simulation deaktiviert');
             $this->WriteAttributeString('SimulationData', '[]');
             $this->SetTimerInterval('UpdateTargetsTimer', 0);
-            $this->SetValue('NextTrigger', 'Keiner');
+            $this->SetValue('NextTrigger', 0);
             $this->SetTimerInterval('MidnightTimer', 0);
             $this->SetValue('SimulationView', 'Simulation deaktiviert');
             IPS_SetHidden($this->GetIDForIdent('SimulationView'), true);
@@ -381,7 +381,7 @@ class AnwesenheitsSimulation extends IPSModule
             $this->SetValue('NextTrigger', (date("H:i:s", ($NextSimulationData['nextSwitchTimestamp']))));
         } else {
             $this->SetTimerInterval('UpdateTargetsTimer', 0);
-            $this->SetValue('NextTrigger', 'Keiner');
+            $this->SetValue('NextTrigger', 0);
         }
         $this->SetTimerInterval('UpdateTargetsTimer', 1000 * (strtotime('tomorrow', $this->getTime()) - $this->getTime()));
     }

--- a/AnwesenheitsSimulation/module.php
+++ b/AnwesenheitsSimulation/module.php
@@ -25,6 +25,7 @@ class AnwesenheitsSimulation extends IPSModule
 
         //Variables
         $this->RegisterVariableString('SimulationView', $this->Translate('Simulation preview'), '~HTMLBox');
+        $this->RegisterVariableString('NextTrigger', $this->Translate('Next Trigger'), '');
         $this->RegisterVariableString('SimulationDay', $this->Translate('Simulations source (Day)'), '');
         $this->RegisterVariableBoolean('Active', $this->Translate('Simulation active'), '~Switch');
         $this->EnableAction('Active');
@@ -150,6 +151,7 @@ class AnwesenheitsSimulation extends IPSModule
             $this->SetValue('SimulationDay', 'Simulation deaktiviert');
             $this->WriteAttributeString('SimulationData', '[]');
             $this->SetTimerInterval('UpdateTargetsTimer', 0);
+            $this->SetValue('NextTrigger'), 'Keiner');
             $this->SetTimerInterval('MidnightTimer', 0);
             $this->SetValue('SimulationView', 'Simulation deaktiviert');
             IPS_SetHidden($this->GetIDForIdent('SimulationView'), true);
@@ -376,8 +378,10 @@ class AnwesenheitsSimulation extends IPSModule
 
         if (isset($NextSimulationData['nextSwitchTimestamp'])) {
             $this->SetTimerInterval('UpdateTargetsTimer', ($NextSimulationData['nextSwitchTimestamp'] - $this->getTime() + 1) * 1000);
+            $this->SetValue('NextTrigger'), (date("H:i:s", ($NextSimulationData['nextSwitchTimestamp']))));
         } else {
             $this->SetTimerInterval('UpdateTargetsTimer', 0);
+            $this->SetValue('NextTrigger'), 'Keiner');
         }
         $this->SetTimerInterval('UpdateTargetsTimer', 1000 * (strtotime('tomorrow', $this->getTime()) - $this->getTime()));
     }

--- a/AnwesenheitsSimulation/module.php
+++ b/AnwesenheitsSimulation/module.php
@@ -378,7 +378,7 @@ class AnwesenheitsSimulation extends IPSModule
 
         if (isset($NextSimulationData['nextSwitchTimestamp'])) {
             $this->SetTimerInterval('UpdateTargetsTimer', ($NextSimulationData['nextSwitchTimestamp'] - $this->getTime() + 1) * 1000);
-            $this->SetValue('NextTrigger', (date("H:i:s", ($NextSimulationData['nextSwitchTimestamp']))));
+            $this->SetValue('NextTrigger', ($NextSimulationData['nextSwitchTimestamp'] - $this->getTime() + 1) * 1000);
         } else {
             $this->SetTimerInterval('UpdateTargetsTimer', 0);
             $this->SetValue('NextTrigger', 0);

--- a/AnwesenheitsSimulation/module.php
+++ b/AnwesenheitsSimulation/module.php
@@ -151,7 +151,7 @@ class AnwesenheitsSimulation extends IPSModule
             $this->SetValue('SimulationDay', 'Simulation deaktiviert');
             $this->WriteAttributeString('SimulationData', '[]');
             $this->SetTimerInterval('UpdateTargetsTimer', 0);
-            $this->SetValue('NextTrigger'), 'Keiner');
+            $this->SetValue('NextTrigger', 'Keiner');
             $this->SetTimerInterval('MidnightTimer', 0);
             $this->SetValue('SimulationView', 'Simulation deaktiviert');
             IPS_SetHidden($this->GetIDForIdent('SimulationView'), true);
@@ -378,10 +378,10 @@ class AnwesenheitsSimulation extends IPSModule
 
         if (isset($NextSimulationData['nextSwitchTimestamp'])) {
             $this->SetTimerInterval('UpdateTargetsTimer', ($NextSimulationData['nextSwitchTimestamp'] - $this->getTime() + 1) * 1000);
-            $this->SetValue('NextTrigger'), (date("H:i:s", ($NextSimulationData['nextSwitchTimestamp']))));
+            $this->SetValue('NextTrigger', (date("H:i:s", ($NextSimulationData['nextSwitchTimestamp']))));
         } else {
             $this->SetTimerInterval('UpdateTargetsTimer', 0);
-            $this->SetValue('NextTrigger'), 'Keiner');
+            $this->SetValue('NextTrigger', 'Keiner');
         }
         $this->SetTimerInterval('UpdateTargetsTimer', 1000 * (strtotime('tomorrow', $this->getTime()) - $this->getTime()));
     }


### PR DESCRIPTION
I have added a new variable which indicates when the next light must be switched on or off. As I still have the problem that in some cases the internal timer gets inactive, I would use this "NextTrigger" variable as a WatchDog.